### PR TITLE
Pcf 77 pancan multiqc config v1.0.0

### DIFF
--- a/PANCAN/PanCan_multiqc_config_v1.0.0.yaml
+++ b/PANCAN/PanCan_multiqc_config_v1.0.0.yaml
@@ -110,6 +110,10 @@ module_order:
             module_tag:
                 - RNA
 
+table_columns_visible:
+    FastQC:
+        avg_sequence_length: True
+
 # Specify order in which table columns are visible in General Statistics
 table_columns_placement:
     general_stats_table:

--- a/PANCAN/PanCan_multiqc_config_v1.0.0.yaml
+++ b/PANCAN/PanCan_multiqc_config_v1.0.0.yaml
@@ -1,0 +1,167 @@
+###################################################
+# Eggd MultiQC Configuration File for PanCancer
+###################################################
+
+# This file can be saved either in the MultiQC installation
+# directory, or as ~/.multiqc_config.yaml
+
+# Configuration settings are taken from the following locations, in order:
+# - Hardcoded in MultiQC (multiqc/utils/config.py)
+# - <installation_dir>/multiqc_config.yaml
+# - ~/.multiqc_config.yaml
+# - Command line options
+
+# Note that all of the values below are set to the MultiQC defaults.
+# It's recommended that you delete any that you don't need.
+
+#################################################################
+
+# Title to use for the report.
+title: East GLH MultiQC Report
+subtitle: "PanCancer"    # Grey text below title
+# intro_text: null          # Set to False to remove, or your own text
+
+# # Add generic information to the top of reports
+# report_header_info:
+#     - Example Config:: 'This is arbitrary'
+#     - Another field:: 'Loaded from <code>multiqc_config_example.yaml</code>'
+#     - Something different:: 'You can put any key-value pairs here'
+#     - Want to know more?: 'See the <a href="http://multiqc.info/docs" target="_blank">MultiQC docs</a>'
+# # Specify a custom logo to add to reports (uncomment to use)
+# custom_logo: 'link to egglogo.png'         # '/path/to/logo.png'
+# custom_logo_url: 'https://cuhbioinformatics.atlassian.net/servicedesk/customer/portal/3'     # 'https://www.example.com'
+# custom_logo_title: 'Bioinformatics Help Desk'   # 'Our Institute Name'
+
+# Default output filenames
+output_fn_name: multiqc_report.html
+data_dir_name: multiqc_data
+
+# Prepend sample names with their directory. Useful if analysing the
+# sample samples with different parameters.
+prepend_dirs: False
+# Whether to create the parsed data directory in addition to the report
+make_data_dir: True
+
+# Cleaning options for sample names. Typically, sample names are detected
+# from an input filename. If any of these strings are found, they and any
+# text to their right will be discarded.
+# For example - file1.fq.gz_trimmed.bam_deduplicated_fastqc.zip
+# would be cleaned to 'file1'
+# Two options here - fn_clean_exts will replace the defaults,
+# extra_fn_clean_exts will append to the defaults
+extra_fn_clean_exts:
+    - type: remove
+      pattern: '_001'
+    - type: remove
+      pattern: '.markdup'
+    - type: remove
+      pattern: '_markdup'
+    - type: remove
+      pattern: '.realigned'
+    - type: remove
+      pattern: '_metrics'
+    - type: remove
+      pattern: '.Duplication_metrics'
+    - type: remove
+      pattern: '.Duplication'
+    - type: remove
+      pattern: '.duplication'
+    - type: remove
+      pattern: '.AlignmentStat'
+    - type: remove
+      pattern: '.GCBias'
+    - type: remove
+      pattern: '.InsertSize'
+    - type: remove
+      pattern: '.MeanQualityByCycle_metrics'
+    - type: remove
+      pattern: '.QualDistribution_metrics'
+
+# Ignore files larger than this when searcing for logs (bytes)
+log_filesize_limit: 5000000000
+# MultiQC skips a couple of debug messages when searching files as the
+# log can get very verbose otherwise. Re-enable here to help debugging.
+report_readerrors: False
+report_imgskips: False
+# Opt-out of remotely checking that you're running the latest version
+no_version_check: False
+
+# How to plot graphs. Different templates can override these settings, but
+# the default template can use interactive plots (Javascript using HighCharts)
+# or flat plots (images, using MatPlotLib). With interactive plots, the report
+# can prevent automatically rendering all graphs if there are lots of samples
+# to prevent the browser being locked up when the report opens.
+plots_force_flat: False          # Try to use only flat image graphs
+plots_force_interactive: False   # Try to use only interactive javascript graphs
+plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
+num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
+max_table_rows: 500              # Swap tables for a beeswarm plot above this
+
+# Overwrite module order (in report).
+# See multiqc/utils/config_defaults.yaml for the defaults.
+module_order:
+    - fastqc:
+        module_tag:
+            - RNA
+    - picard:
+        module_tag:
+            - RNA
+    - rna_seqc:
+            module_tag:
+                - RNA
+
+# Specify order in which table columns are visible in General Statistics
+table_columns_placement:
+    general_stats_table:
+        total_sequences: 910                    # M Reads Mapped
+        avg_sequence_length: 920                # length
+        percent_duplicates: 930                 # dups
+        percent_gc: 940                         # gc
+        Expression_Profiling_Efficiency: 950    # expression efficiency
+        Genes_Detected: 960                     # genes
+        PCT_MRNA_BASES: 970                     # mRNA
+        rRNA_rate: 980                          # rRNA alignment
+        PCT_RIBOSOMAL_BASES: 990                # rRNA
+
+
+# Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
+# for the defaults. Remove a default by setting it to null.
+sp:
+    fastqc/data:
+        fn: '*.stats-fastqc.txt'
+    picard/rnaseqmetrics:
+        fn: '*.RNAmetrics.tsv'
+        shared: true
+    picard/hsmetrics:
+        fn: '*.hsmetrics.tsv'
+        shared: true
+    rna_seqc/metrics_v1:
+      fn: "*.metrics.tsv"
+      contents: "Sample	Note	"
+      shared: true
+    rna_seqc/metrics_v2:
+      fn: "*.metrics.tsv"
+      contents: "High Quality Ambiguous Alignment Rate"
+      shared: true
+    rna_seqc/coverage:
+      fn_re: 'meanCoverageNorm_(high|medium|low)\.txt'
+
+
+# # Remove plots from HTML report
+# remove_sections:
+
+# # Remove module sections from HTML report
+# exclude_modules:
+
+# Specify location and file extensions of QC metrics to be downloaded
+# to the workstation by the app:
+dx_sp:
+    primary:
+        fastqc:
+            - '*.stats-fastqc.txt'
+        picard/QC:
+            - '*.RNAmetrics.tsv'
+            - '*.hsmetrics.tsv'
+        rna_seqc:
+            - "*.metrics.tsv"
+


### PR DESCRIPTION
First version of multiQC config. Ordered the general stats column + included length column.
example job: https://platform.dnanexus.com/panx/projects/GYxKj504k171KX9QPxp19q49/monitor/job/GbqZJ484k176qX4zx7z1qY3k

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/8)
<!-- Reviewable:end -->
