### PR TITLE
DI-1239 WES grch38 v1 fix insert size threshold

### DIFF
--- a/TWE/WES_multiqc_config_GRCh38_v1.0.0.yaml
+++ b/TWE/WES_multiqc_config_GRCh38_v1.0.0.yaml
@@ -201,8 +201,8 @@ table_cond_formatting_rules:
     mqc-generalstats-sentieon-summed_median: # Sentieon Insert Size column in General Stats
         pass:
             - gt: 190
-        warn:
             - eq: 190
+        warn:
             - lt: 190
     # Columns in tables from other modules
     mean_het: # vcf_qc mean_het column


### PR DESCRIPTION
Fix insert size threshold:
- `pass: - gt: 190` -> `pass: - gt: 190 and - eq: 190`
- `warn: - eq: 190 and -lt: 190` ->  `warn: - lt: 190`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/22)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `custom_data` section for enhanced report customisation.
	- Added a `custom_plot_config` section for improved visual consistency.
  
- **Bug Fixes**
	- Adjusted warning conditions for the `mqc-generalstats-sentieon-summed_median` metric.

- **Improvements**
	- Updated exclusion of the `somalier` module from the HTML report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->