### PR TITLE
DI-1154 CEN GRCh38 v1.0.0

### DIFF
--- a/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
+++ b/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
@@ -278,17 +278,6 @@ table_cond_formatting_rules:
             - lt: 1350
             - eq: 1350
 
-    # all_columns:
-    #     pass:
-    #         - s_eq: 'pass'
-    #         - s_eq: 'true'
-    #     warn:
-    #         - s_eq: 'warn'
-    #         - s_eq: 'unknown'
-    #     fail:
-    #         - s_eq: 'fail'
-    #         - s_eq: 'false'
-
 # Add code to include data from custom QC data files
 custom_data:
     vcf_qc_files:

--- a/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
+++ b/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
@@ -1,0 +1,482 @@
+###################################################
+# Eggd MultiQC Configuration File for CEN
+###################################################
+
+# This file can be saved either in the MultiQC installation
+# directory, or as ~/.multiqc_config.yaml
+
+# Configuration settings are taken from the following locations, in order:
+# - Hardcoded in MultiQC (multiqc/utils/config.py)
+# - <installation_dir>/multiqc_config.yaml
+# - ~/.multiqc_config.yaml
+# - Command line options
+
+# Note that all of the values below are set to the MultiQC defaults.
+# It's recommended that you delete any that you don't need.
+
+#################################################################
+
+# Title to use for the report.
+title: East GLH MultiQC Report
+subtitle: Cancer Endocrine Neurology     # Grey text below title
+# intro_text: null      # Set to False to remove, or your own text
+
+# # Add generic information to the top of reports
+# report_header_info:
+#     - Example Config:: 'This is arbitrary'
+#     - Another field:: 'Loaded from <code>multiqc_config_example.yaml</code>'
+#     - Something different:: 'You can put any key-value pairs here'
+#     - Want to know more?: 'See the <a href="http://multiqc.info/docs" target="_blank">MultiQC docs</a>'
+# # Specify a custom logo to add to reports (uncomment to use)
+# custom_logo: 'link to egglogo.png'         # '/path/to/logo.png'
+# custom_logo_url: 'https://cuhbioinformatics.atlassian.net/servicedesk/customer/portal/3'     # 'https://www.example.com'
+# custom_logo_title: 'Bioinformatics Help Desk'   # 'Our Institute Name'
+
+# Default output filenames
+output_fn_name: multiqc_report.html
+data_dir_name: multiqc_data
+
+# Prepend sample names with their directory. Useful if analysing the
+# sample samples with different parameters.
+prepend_dirs: False
+# Whether to create the parsed data directory in addition to the report
+make_data_dir: True
+
+# Cleaning options for sample names. Typically, sample names are detected
+# from an input filename. If any of these strings are found, they and any
+# text to their right will be discarded.
+# For example - file1.fq.gz_trimmed.bam_deduplicated_fastqc.zip
+# would be cleaned to 'file1'
+# Two options here - fn_clean_exts will replace the defaults,
+# extra_fn_clean_exts will append to the defaults
+extra_fn_clean_exts:
+    - type: remove
+      pattern: '_001'
+    - type: remove
+      pattern: '.markdup'
+    - type: remove
+      pattern: '_markdup'
+    - type: remove
+      pattern: '.realigned'
+    - type: remove
+      pattern: '_metrics'
+    - type: remove
+      pattern: '.Duplication_metrics'
+    - type: remove
+      pattern: '.Duplication'
+    - type: remove
+      pattern: '.duplication'
+    - type: remove
+      pattern: '.AlignmentStat'
+    - type: remove
+      pattern: '.GCBias'
+    - type: remove
+      pattern: '.InsertSize'
+    - type: remove
+      pattern: '.MeanQualityByCycle_metrics'
+    - type: remove
+      pattern: '.QualDistribution_metrics'
+    # - .gz
+    # - .fastq
+    # - .fq
+    # - .bam
+    # - .sam
+    # - _fastqc
+    # - type: replace
+    #   pattern: '.sorted'
+    # - type: regex
+    #   pattern: '^Sample_\d+'
+
+# Ignore files larger than this when searcing for logs (bytes)
+log_filesize_limit: 5000000000
+# MultiQC skips a couple of debug messages when searching files as the
+# log can get very verbose otherwise. Re-enable here to help debugging.
+report_readerrors: False
+report_imgskips: False
+# Opt-out of remotely checking that you're running the latest version
+no_version_check: False
+
+# How to plot graphs. Different templates can override these settings, but
+# the default template can use interactive plots (Javascript using HighCharts)
+# or flat plots (images, using MatPlotLib). With interactive plots, the report
+# can prevent automatically rendering all graphs if there are lots of samples
+# to prevent the browser being locked up when the report opens.
+plots_force_flat: False          # Try to use only flat image graphs
+plots_force_interactive: True   # Try to use only interactive javascript graphs
+plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
+num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
+max_table_rows: 500              # Swap tables for a beeswarm plot above this
+
+# Overwrite module order displayed in report.
+# See multiqc/utils/config_defaults.yaml for the defaults.
+module_order:
+    - happy:
+        module_tag:
+            - DNA
+    - 'custom_content'
+    - verifybamid:
+        info: "detects sample contamination."
+        module_tag:
+            - DNA
+    - picard:
+        module_tag:
+            - DNA
+    - sentieon:
+        module_tag:
+            - DNA
+    - samtools:
+        module_tag:
+            - DNA
+    - fastqc:
+        module_tag:
+            - RNA
+    - bcl2fastq:
+        module_tag:
+            - DNA
+
+# Overwrite the defaults of which table columns are visible by default
+table_columns_visible:
+    bcl2fastq: False
+    FastQC: False
+    Picard:
+        FOLD_ENRICHMENT: False
+    verifyBAMID:
+        CHIPMIX: False
+
+# Specify order in which table columns are visible in General Statistics
+table_columns_placement:
+    general_stats_table:
+        mapped_passed: 950
+        FREEMIX: 960
+        PCT_TARGET_BASES_20X: 970
+        percent_duplicates: 980
+        PCT_PF_READS_ALIGNED: 990
+        summed_median: 1000
+    picard_hsmetrics_table: # Specify the order in which table columns are visible in HSmetrics
+        BAIT_DESIGN_EFFICIENCY: 780
+        FOLD_80_BASE_PENALTY: 790
+        FOLD_ENRICHMENT: 800
+        HET_SNP_Q: 810
+        HET_SNP_SENSITIVITY: 820
+        MAX_TARGET_COVERAGE: 830
+        MEAN_BAIT_COVERAGE: 840
+        MEAN_TARGET_COVERAGE: 850
+        MEDIAN_TARGET_COVERAGE: 860
+        NEAR_BAIT_BASES: 870
+        OFF_BAIT_BASES: 880
+        ON_BAIT_BASES: 890
+        ON_BAIT_VS_SELECTED: 900
+        ON_TARGET_BASES: 910
+        PCT_USABLE_BASES_ON_BAIT: 920
+        PCT_USABLE_BASES_ON_TARGET: 930
+        PF_BASES_ALIGNED: 940
+        PF_READS: 950
+        PF_UNIQUE_READS: 960
+        PF_UQ_BASES_ALIGNED: 970
+        PF_UQ_READS_ALIGNED: 980
+        ZERO_CVG_TARGETS_PCT: 990
+        PCT_SELECTED_BASES: 1000
+
+# Set picard configs: TARGET BASES COVERAGE
+picard_config:
+    general_stats_target_coverage: # should be referred to as 'mqc-generalstats-picard-PCT_TARGET_BASES_20X'
+        - 20                        # for conditional table formatting
+
+table_cond_formatting_colours:
+    - blue: '#337ab7'
+    - lbue: '#5bc0de'
+    - pass: '#5cb85c'
+    - warn: '#f0ad4e'
+    - fail: '#d9534f'
+
+
+# Set conditional formatting rules for general stats
+table_cond_formatting_rules:
+    mqc-generalstats-picard-PCT_TARGET_BASES_20X: # Percentage of target bases at 20x
+        pass:                                     # number in name depends on what is set above
+            - lt: 101
+        warn:
+            - eq: 99.9
+            - lt: 99.9
+        fail:
+            - eq: 99.0
+            - lt: 99.0
+    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contamination column in General Stats
+        pass:
+            - lt: 1
+        fail:
+            - eq: 1
+            - gt: 1
+    mqc-generalstats-sentieon-summed_median: # Sentieon Insert Size column in General Stats
+        pass:
+            - gt: 175
+            - eq: 175
+        warn:
+            - lt: 175
+# Set conditional formatting rules for other modules
+    mean_het: # vcf_qc mean_het column
+        pass:
+            - gt: 0
+        fail:
+            - lt: 0.455
+            - gt: 0.486
+    FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
+        pass:
+            - lt: 1.30
+        warn:
+            - eq: 1.30
+            - gt: 1.30
+    FREEMIX: #verifyBamId Contamination column in verifybamid
+        pass:
+            - lt: 1
+        fail:
+            - eq: 1
+            - gt: 1
+    METRIC_Recall_indel: # Happy indel Recall outputs
+        pass:
+            - gt: 0.800
+            - eq: 0.800
+        fail:
+            - lt: 0.800
+    METRIC_Precision_indel: # Happy indel Precision outputs
+        pass:
+            - gt: 0.820
+            - eq: 0.820
+        fail:
+            - lt: 0.820
+    METRIC_Recall_snp:  # Happy snp Recall outputs
+        pass:
+            - eq: 1.00
+        warn:
+            - lt: 1.00
+        fail:
+            - lt: 0.985
+    METRIC_Precision_snp:  # Happy snp Precision outputs
+        pass:
+            - eq: 1.000
+        warn:
+            - lt: 1.000
+        fail:
+            - lt: 0.990
+    Match_Sexes:  # Somalier Matching Sex column
+        true:
+            - s_eq: 'pass'
+        fail:
+            - s_eq: 'fail'
+        warn:
+            - s_eq: 'NA'
+    original_pedigree_sex: # Somalier Reported sex column
+        warn:
+            - s_eq: 'none'
+    FOLD_ENRICHMENT: # Picard HSMetrics fold enrichment column
+        pass:
+            - gt: 1400
+        warn:
+            - eq: 1400
+            - gt: 1400
+        fail:
+            - lt: 1350
+            - eq: 1350
+
+    # all_columns:
+    #     pass:
+    #         - s_eq: 'pass'
+    #         - s_eq: 'true'
+    #     warn:
+    #         - s_eq: 'warn'
+    #         - s_eq: 'unknown'
+    #     fail:
+    #         - s_eq: 'fail'
+    #         - s_eq: 'false'
+
+# Add code to include data from custom QC data files
+custom_data:
+    vcf_qc_files:
+        file_format: 'tsv'
+        section_name: 'Het-hom analysis'
+        description: 'This plot comes from vcf_qc files'
+        plot_type: 'table'
+        pconfig:
+            id: 'het-hom_table'
+            table_title: 'Het-hom'
+            'col1_header': 'Sample'
+            'col2_header': 'mean_het'
+            'col3_header': 'mean_hom'
+            'col4_header': 'het_hom_ratio'
+            'col5_header': 'x_het_hom_ratio'
+        headers:
+            x_het_hom_ratio:
+                title: 'X het:homo ratio'
+                format:  '{:,.4f}'
+                placement: 970
+            het_hom_ratio:
+                title: 'Het:homo ratio'
+                format:  '{:,.4f}'
+                placement: 980
+            mean_het:
+                title: 'Mean het ratio'
+                format:  '{:,.4f}'
+                placement: 990
+            mean_hom:
+                title: 'Mean homo ratio'
+                format:  '{:,.4f}'
+                placement: 1000
+    somalier_files:
+        file_format: 'tsv'
+        section_name: 'Somalier'
+        description: 'Checking predicted sex is same as reported'
+        plot_type: 'table'
+        pconfig:
+            id: 'somalier_table'
+            table_title: 'Sex check'
+            'col1_header': 'sample_id'
+            'col7_header': 'original_pedigree_sex'
+            'col19_header': 'X_depth_mean'
+            'col20_header': 'X_n'
+            'col21_header': 'X_hom_ref'
+            'col22_header': 'X_het'
+            'col23_header': 'X_hom_alt'
+            'col24_header': 'Y_depth_mean'
+            'col25_header': 'Y_n'
+            'col26_header': 'Predicted_Sex'
+            'col27_header': 'Match_Sexes'
+        headers:
+            sample_id:
+                title: 'Sample ID'
+            original_pedigree_sex:
+                title: 'Reported sex'
+                description: 'Expected sex reported from filename'
+            X_depth_mean:
+                title: 'X_depth_mean'
+                description: 'Mean depth on X chromosome'
+            X_n:
+                title: 'X total'
+                description: 'Total variant calls on X chromosome'
+                format:  '{:,.0f}'
+            X_hom_ref:
+                title: 'X_hom_ref'
+                description: 'Homozygous ref variant calls on X chromosome'
+                format:  '{:,.0f}'
+            X_het:
+                title: 'X_het'
+                description: 'Heterozygosity variant calls on X chromosome'
+                format:  '{:,.0f}'
+            X_hom_alt:
+                title: 'X_hom_alt'
+                description: 'Homozygous alt variant calls on X chromosome'
+                format:  '{:,.0f}'
+            Y_depth_mean:
+                title: 'Y_depth_mean'
+                description: 'Mean depth on Y chromosome'
+            Y_n:
+                title: 'Y_n'
+                description: 'Total variant calls on Y chromosome'
+                format:  '{:,.0f}'
+            Predicted_Sex:
+                title: 'Predicted sex'
+                description: 'Predicted sex based on thresholds on X_het'
+            Match_Sexes:
+                title: 'Matching sex'
+                description: 'Whether reported and predicted sex of sample match'
+
+# Add a fixed scale of the Y-axis on the Picard GC bias plot
+custom_plot_config:
+    sentieon_gcbias_plot:
+        yCeiling: 100
+
+custom_table_header_config:
+    picard_hsmetrics_table:
+        FOLD_80_BASE_PENALTY:
+            format: "{:,.3f}"
+        FOLD_ENRICHMENT:
+            format: "{:,.2f}"
+    general_stats_table:
+        PCT_TARGET_BASES_20X:
+            format: "{:,.2f}"
+
+# Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
+# for the defaults. Remove a default by setting it to null.
+sp:
+    bcl2fastq:
+        fn: 'Stats.json'
+    fastqc/data:
+        fn: '*.stats-fastqc.txt'
+    sentieon/alignment_metrics:
+        fn: '*.AlignmentStat_metrics.txt'
+        shared: true
+    sentieon/markdups:
+        fn: '*.Duplication_metrics.txt'
+        shared: true
+    sentieon/gcbias:
+        fn: '*.GCBias_metrics.txt'
+        shared: true
+    sentieon/insertsize:
+        fn: '*.InsertSize_metrics.txt'
+        shared: true
+    picard/hsmetrics:
+        fn: '*.hsmetrics.tsv'
+        shared: true
+    picard/pcr_metrics:
+        fn: '*.pertarget_coverage.tsv'
+        shared: true
+    picard/quality_by_cycle:
+        fn: '*.MeanQualityByCycle_metrics.txt'
+        shared: true
+    picard/quality_score_distribution:
+        fn: '*.QualDistribution_metrics.txt'
+        shared: true
+    verifybamid/selfsm:
+        fn: '*.selfSM'
+    samtools/flagstat:
+        fn: '*.flagstat'
+        contents: 'in total (QC-passed reads + QC-failed reads)'
+        shared: true
+    happy:
+        fn: "*.summary.csv"
+        contents: "Type,Filter,TRUTH"
+    vcf_qc_files:
+        fn: '*.vcf.QC'
+    somalier_files:
+        fn: '*_somalier.samples.tsv'
+
+# Remove plots from HTML report
+# remove_sections:
+
+# Remove module sections from HTML report
+exclude_modules:
+    - somalier
+
+# Specify location and file extensions of QC metrics to be downloaded
+# to the workstation by the app:
+dx_sp:
+    primary:
+        fastqc:
+            - '*.stats-fastqc.txt'
+        sentieon/sample:
+            - '*.AlignmentStat_metrics.txt'
+            - '*.Duplication_metrics.txt'
+            - '*.GCBias_metrics.txt'
+            - '*.InsertSize_metrics.txt'
+            # - '*.MeanQualityByCycle_metrics.txt'
+            # - '*.QualDistribution_metrics.txt'
+        picard/QC:
+            - '*.hsmetrics.tsv'
+            - '*.pertarget_coverage.tsv'
+        verifybamid/QC:
+            - '*.selfSM'
+            # - '*.depthSM'
+        samtools:
+            - '*.flagstat'
+        vcf_qc:
+            - '*.vcf.QC'
+        somalier_relate2multiqc:
+            - '*_somalier.samples.tsv'
+        vcfeval_hap.py:
+            - "*.summary.csv"
+        sex_check:
+            - "*_mqc.json"
+    secondary:
+        somalier_relate2multiqc:
+            - '*_somalier.samples.tsv'
+        vcfeval_hap.py:
+            - "*.summary.csv"

--- a/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
+++ b/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
@@ -273,7 +273,7 @@ table_cond_formatting_rules:
             - gt: 1400
         warn:
             - eq: 1400
-            - gt: 1400
+            - lt: 1400
         fail:
             - lt: 1350
             - eq: 1350


### PR DESCRIPTION
- Adds additional GRCh38 CEN MultiQC v1 config file which is a copy of the GRCh37 version with relevant fields edited (decision was made to keep both GRCh37 and GRCh38 WES configs in the repo)
Relevant changes compared to GRCh37:
  - Updates FREEMIX threshold
  - Updates PCT_TARGET_BASES_20X threshold (and updates format to 2dp)
  - Updates FOLD_ENRICHMENT threshold (and updates format to 2dp)
  - Updates eggd_vcf_qc field names to match v2.0.0+
  - Updates eggd_vcf_qc mean_het threshold (and updates format to 4dp and specifies column ordering to match what is currently shown in MultiQC report in GRCh37)
  - New Sentieon insert size warning threshold
  - Updates hap.py thresholds
  - Update Somalier section name from 'Somalier Sex Check' -> 'Somalier' (https://github.com/eastgenomics/eggd_MultiQC_configs/issues/18 )

Relevant doc: https://cuhbioinformatics.atlassian.net/wiki/spaces/DV/pages/3420815372/CEN+GRCh38+QC+Thresholds+v1.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/25)
<!-- Reviewable:end -->
