### PR TITLE
Di 2271 cen multiqc config gr ch38 v1.1.0.yaml

### DIFF
--- a/CEN/CEN_multiqc_config_GRCh38_v1.1.0.yaml
+++ b/CEN/CEN_multiqc_config_GRCh38_v1.1.0.yaml
@@ -151,8 +151,8 @@ table_columns_placement:
         verifybamid-FREEMIX: 960
         picard_hsmetrics-picard_target_bases_20X: 970
         picard_hsmetrics-FOLD_ENRICHMENT: 980
-        picard_insertsizemetrics-summed_median: 990
-        picard_mark_duplicates-PERCENT_DUPLICATION: 1000
+        picard_mark_duplicates-PERCENT_DUPLICATION: 990
+        picard_insertsizemetrics-summed_median: 1000
     picard_hsmetrics_table: # Specify the order in which table columns are visible in HSmetrics
         hsmetrics-BAIT_DESIGN_EFFICIENCY: 780
         hsmetrics-FOLD_80_BASE_PENALTY: 790


### PR DESCRIPTION
Changes to accommodate eggd_MultiQC_v3.2.0:
-  change report_readerrors to 0
-  Specify turn off of AI
- Move Sentieon functionality to picard
- Remove `module_tag`s from **module order**
- Specify  app of origin for each metric in table_columns_placement
-  Specify  app of origin for some metric in table_cond_formatting_rules
-  Remove table title and column headers from custom_data:somalier_files

Changes to accomodate picard variant calling metrics and interop data
- Add picard and interop to **module_order**
- add picard and interop files to sp
- add picard file variant_calling_detail_metrics to dx_sp

Overwrite samtools-flagstats default to present a table instead of a table

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/37)
<!-- Reviewable:end -->
