### PR TITLE
WES GRCh38 yaml changes

### DIFF
--- a/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
+++ b/CEN/CEN_multiqc_config_GRCh38_v1.0.0.yaml
@@ -201,7 +201,7 @@ table_cond_formatting_rules:
         fail:
             - eq: 99.0
             - lt: 99.0
-    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contamination column in all tables
+    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contamination column in General Stats
         pass:
             - lt: 1
         fail:

--- a/TWE/WES_multiqc_config_GRCh38_v1.1.0.yaml
+++ b/TWE/WES_multiqc_config_GRCh38_v1.1.0.yaml
@@ -201,7 +201,7 @@ table_cond_formatting_rules:
         fail:
             - eq: 95.0
             - lt: 95.0
-    verifybamid-FREEMIX: #verifyBamId Contamination column in General Stats
+    verifybamid-FREEMIX: #verifyBamId Contamination column in all tables
         pass:
             - lt: 1
         fail:


### PR DESCRIPTION
- Update file to v1.1.0
- Add samplesheet table to sp and move this to the end of the report
- Changes to accomodate Eggd_MultiQC v3.2.0:
  - change report_readerrors to 0
  - Disable AI
  - Move Sentieon functionality to Picard
  - Remove module_tags from module order.
  - Change the column ids and column order in the general stats table.
  - Change the column ids and values for in the table_cond_formatting_rules.
  - Remove table title and column headers from custom_data for somalier and het-hom tables.
- Changes to accommodate picard variant calling metrics and interop data:
  - Add interop and delete sentieon from module_order
  - Set Picard HSMetrics to be first in the Picard subsection. Add picard and interop files to sp
  - Add picard file variant_calling_detail_metrics to dx_sp
- Changes to accomodate samtools flagstat:
  - Overwrite samtools-flagstats default to present a table instead of a violin plot
  - Add thresholds for mapped_passed, with_mate_mapped_to_a_different_chr_passed and supplementary_passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/41)
<!-- Reviewable:end -->
