### PR TITLE
added custom_table_header_config section and ensured that picard pica…

### DIFF
--- a/TSO500/TSO500_multiqc_config_v2.2.1.yaml
+++ b/TSO500/TSO500_multiqc_config_v2.2.1.yaml
@@ -221,6 +221,17 @@ module_order:
     - picard
     - interop
 
+
+custom_table_header_config:
+  general_stats_table:
+      picard_hsmetrics-MEDIAN_TARGET_COVERAGE:
+          hidden: true
+      picard_variantcallingmetrics-DBSNP_TITV:
+          hidden: true
+      picard_variantcallingmetrics-NOVEL_TITV:
+          hidden: true
+
+
 # Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
 # for the defaults. Remove a default by setting it to null.
 sp:


### PR DESCRIPTION
…rd_variantcallingmetrics-DBSNP_TITV and picard_variantcallingmetrics-NOVEL_TITV would be hidden from the general_stats_table

Added a custom_table_header_config section that hides Picard QC metrics from the general_stats_table to solve issue #39.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/42)
<!-- Reviewable:end -->
