### PR TITLE
CEN GRCh38 v1.2.0

### DIFF
--- a/CEN/CEN_multiqc_config_GRCh38_v1.2.0.yaml
+++ b/CEN/CEN_multiqc_config_GRCh38_v1.2.0.yaml
@@ -307,7 +307,7 @@ table_cond_formatting_rules:
     samtools_flagstat-mapped_passed:
         warn:
             - lt: 20.0
-    samtools-flagstat-dp_table-mapped_passed:
+    mapped_passed:
         warn:
             - lt: 20.0
 


### PR DESCRIPTION
- Make with_mate_mapped_to_a_different_chr_passed and supplementary_passed display as 3dp in report
- Include warning threshold for mapped_passed in samtools flagstat table

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/44)
<!-- Reviewable:end -->
