### PR TITLE
Changes for mye multiqc config v4.1.0.yaml

### DIFF
--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -125,14 +125,14 @@ module_order:
 
 # Make the samplesheet_samplename_patterns subsection
 report_section_order:
-    samplesheet_samplename_patterns:
-        order: 10
     general_stats:
         order: 10000
     sompy:
         order: 9990
     sex_check:
         order: 9980
+    samplesheet_samplename_patterns:
+        order: 10
 
 # Overwrite the defaults of which table columns are visible by default
 # in the General Statistics table


### PR DESCRIPTION
- Compatibility changes from v2.0.1 to v3.2.0
  - Delete report_imgskips
  - Change report_readerrors: False to 0
  - remove module_tag and info from module_order
- Include sp paths for:
  - picard/variant_calling_metrics
  - interop data
  - samplesheet files
- Specify the MultiQC sompy module in `module_order`
- Hide columns from the general stats table
- Hide the Het/Hom Ratio column from picard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/51)
<!-- Reviewable:end -->
