### PR TITLE
Di 2757 mye multiqc config v4.1.0.yaml

### DIFF
--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -125,14 +125,14 @@ module_order:
 
 # Make the samplesheet_samplename_patterns subsection
 report_section_order:
-    samplesheet_samplename_patterns:
-        order: 10
     general_stats:
         order: 10000
     sompy:
         order: 9990
     sex_check:
         order: 9980
+    samplesheet_samplename_patterns:
+        order: 10
 
 # Overwrite the defaults of which table columns are visible by default
 # in the General Statistics table

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -105,7 +105,6 @@ use_filename_as_sample_name:
     - picard/alignment_metrics
     - picard/markdups
     - picard/gcbias
-    - picard/insertsize
     - picard/pcr_metrics
     - picard/quality_by_cycle
     - picard/quality_score_distribution
@@ -120,6 +119,7 @@ module_order:
     - samtools
     - fastqc
     - bcl2fastq
+    - interop
 
 # Overwrite the defaults of which table columns are visible by default
 # in the General Statistics table
@@ -244,6 +244,22 @@ custom_data:
                 max: 100
                 min: 0
                 suffix: '%'
+    samplesheet_wells:
+        file_format: 'tsv'
+        plot_type: 'generalstats'
+        headers:
+            well_column:
+                title: 'well column'
+            well_row:
+                title: 'well row'
+    samplesheet_samplename_patterns:
+        file_format: 'tsv'
+        plot_type: 'table'
+        headers:
+            well:
+                title: 'Well column / row'
+            samplenames:
+                title: 'Sample name patterns'
 
 # Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
 # for the defaults. Remove a default by setting it to null.

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -271,6 +271,10 @@ sp:
         fn: 'custom_coverage.csv'
     bcl2fastq:
         fn: 'Stats.json'
+    interop/summary:
+        fn: 'interop_summary.csv'
+    interop/index-summary:
+        fn: 'interop_index_summary.csv'
 
 # Remove plots from HTML report
 remove_sections:

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -301,6 +301,7 @@ dx_sp:
             - '*.gc_bias.detail_metrics'
             - '*.insert_size_metrics'
             - '*.pertarget_coverage.tsv'
+            - '*.variantcallingmetrics.variant_calling_detail_metrics'
         verifybamid/QC:
             - '*.selfSM'
         samtools:

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -258,6 +258,8 @@ sp:
     picard/quality_score_distribution:
         fn: '*.quality_distribution_metrics'
         shared: true
+    picard/variant_calling_metrics:
+        fn: '*.variantcallingmetrics.variant_calling_detail_metrics'
     verifybamid/selfsm:
         fn: '*.selfSM'
     samtools/flagstat:

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -114,6 +114,7 @@ use_filename_as_sample_name:
 # See multiqc/utils/config_defaults.yaml for the defaults.
 module_order:
     - 'custom_content'
+    - sompy
     - verifybamid
     - picard
     - samtools

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -114,7 +114,9 @@ use_filename_as_sample_name:
 module_order:
     - 'custom_content'
     - sompy
-    - verifybamid
+    - verifybamid:
+        #Remove the extra description for verifyBAMID
+        extra: ""
     - picard
     - samtools
     - fastqc
@@ -169,7 +171,35 @@ picard_config:
 
 custom_plot_config:
     picard_gcbias_plot:
-        yCeiling: 50
+        yCeiling: 5000
+    samtools-flagstat-table:
+        no_violin: True
+    samtools-flagstat-pct-table:
+        no_violin: True
+
+custom_table_header_config:
+    general_stats_table:
+        custom_content_custom_coverage-500x:
+            hidden: True
+        custom_content_custom_coverage-1000x:
+            hidden: True
+        custom_content_samplesheet_wells-well_column:
+            hidden: True
+        custom_content_samplesheet_wells-well_row:
+            hidden: True
+        picard_hsmetrics-FOLD_ENRICHMENT:
+            hidden: True
+        picard_hsmetrics-MEDIAN_TARGET_COVERAGE:
+            hidden: True
+        picard_hsmetrics-picard_target_bases_100X:
+            hidden: True
+        picard_variantcallingmetrics-DBSNP_TITV:
+            hidden: True
+        picard_variantcallingmetrics-NOVEL_TITV:
+            hidden: True
+    picard_variantcallingmetrics_table:
+        variantcallingmetrics-HET_HOMVAR_RATIO:
+            hidden: True
 
 table_cond_formatting_colours:
     - blue: '#337ab7'

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -37,7 +37,7 @@ output_fn_name: multiqc_report.html
 data_dir_name: multiqc_data
 
 # Prepend sample names with their directory. Useful if analysing the
-# sample samples with different parameters.
+# same samples with different parameters.
 prepend_dirs: False
 # Whether to create the parsed data directory in addition to the report
 make_data_dir: True
@@ -77,12 +77,11 @@ extra_fn_clean_exts:
     - type: remove
       pattern: '.QualDistribution_metrics'
 
-# Ignore files larger than this when searcing for logs (bytes)
+# Ignore files larger than this when searching for logs (bytes)
 log_filesize_limit: 5000000000
 # MultiQC skips a couple of debug messages when searching files as the
 # log can get very verbose otherwise. Re-enable here to help debugging.
-report_readerrors: False
-report_imgskips: False
+report_readerrors: 0
 # Opt-out of remotely checking that you're running the latest version
 no_version_check: False
 
@@ -96,27 +95,18 @@ plots_force_interactive: True   # Try to use only interactive javascript graphs
 plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
 num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
 max_table_rows: 500              # Swap tables for a beeswarm plot above this
+no_ai: True
+plots_num_samples_do_not_automatically_load: 100
 
 # Overwrite module order (in report).
 # See multiqc/utils/config_defaults.yaml for the defaults.
 module_order:
     - 'custom_content'
-    - verifybamid:
-        module_tag:
-            - DNA
-        info: ""
-    - picard:
-        module_tag:
-            - DNA
-    - samtools:
-        module_tag:
-            - DNA
-    - fastqc:
-        module_tag:
-            - DNA
-    - bcl2fastq:
-        module_tag:
-            - DNA
+    - verifybamid
+    - picard
+    - samtools
+    - fastqc
+    - bcl2fastq
 
 # Overwrite the defaults of which table columns are visible by default
 # in the General Statistics table

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -121,6 +121,17 @@ module_order:
     - bcl2fastq
     - interop
 
+# Make the samplesheet_samplename_patterns subsection
+report_section_order:
+    samplesheet_samplename_patterns:
+        order: 10
+    general_stats:
+        order: 10000
+    sompy:
+        order: 9990
+    sex_check:
+        order: 9980
+
 # Overwrite the defaults of which table columns are visible by default
 # in the General Statistics table
 table_columns_visible:
@@ -170,32 +181,25 @@ table_cond_formatting_colours:
 # Set conditional formatting rules
 table_cond_formatting_rules:
     # Columns in the General Statistics table
-    mqc-generalstats-custom_coverage-250x:
+    custom_content_custom_coverage-250x:
         pass:
             - lt: 101
         warn:
             - eq: 90.0
             - lt: 90.0
-    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contaminntion column in General Stats
+    verifybamid-FREEMIX: #verifyBamId Contaminntion column in General Stats
         pass:
             - lt: 10
         warn:
             - eq: 10
             - gt: 10
-    mqc-generalstats-picard-summed_median: # Picard Median Insert Size
+    picard_insertsizemetrics-summed_median: # Picard Median Insert Size
         pass:
             - gt: 150
         warn:
             - eq: 150
             - lt: 150
-    # Columns in tables from other modules
-    FREEMIX: #verifyBamId Contamination column in verifybamid
-        pass:
-            - lt: 10
-        warn:
-            - eq: 10
-            - gt: 10
-    FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
+    hsmetrics-FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
         pass:
             - lt: 1.80
         warn:

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -98,6 +98,18 @@ max_table_rows: 500              # Swap tables for a beeswarm plot above this
 no_ai: True
 plots_num_samples_do_not_automatically_load: 100
 
+# Since Sentieon has been absorbed into Picard module, this is required
+# otherwise it will make all sample names "sorted_0" from the command
+# inside the Sentieon output files
+use_filename_as_sample_name:
+    - picard/alignment_metrics
+    - picard/markdups
+    - picard/gcbias
+    - picard/insertsize
+    - picard/pcr_metrics
+    - picard/quality_by_cycle
+    - picard/quality_score_distribution
+
 # Overwrite module order (in report).
 # See multiqc/utils/config_defaults.yaml for the defaults.
 module_order:
@@ -239,6 +251,9 @@ sp:
         fn: '*.stats-fastqc.txt'
     picard/alignment_metrics:
         fn: '*.alignment_summary_metrics'
+        shared: true
+    picard/markdups:
+        fn: '*.Duplication_metrics.txt'
         shared: true
     picard/insertsize:
         fn: '*.insert_size_metrics'

--- a/MYE/MYE_multiqc_config_v4.1.0.yaml
+++ b/MYE/MYE_multiqc_config_v4.1.0.yaml
@@ -275,6 +275,10 @@ sp:
         fn: 'interop_summary.csv'
     interop/index-summary:
         fn: 'interop_index_summary.csv'
+    samplesheet_wells:
+        fn: 'samplesheet_wells.tsv'
+    samplesheet_samplename_patterns:
+        fn: 'samplesheet_well_samplename_patterns.tsv'
 
 # Remove plots from HTML report
 remove_sections:


### PR DESCRIPTION
Update MYE MultiQC config GRCh38 version number to v4.1.0
Compatibility changes for MultiQC v1.11 -> v3.2.0:
- Disable AI
- Delete report_imgskips
- Change report_readerrors: False to 0
- Remove module_tags from module order.

Include sp paths for:
- picard/variant_calling_metrics
- interop data
- samplesheet files

Specify the MultiQC sompy module in module_order
Hide columns from the general stats table
Hide the Het/Hom Ratio column from picard:
- Het/Hom ratios are currently not relevant to haem-onc analysis - variant calling is performed with mutect2 which does not generate het/hom genotypes, therefore no het/hom ratio can be calculated and the MultiQC column contains only “???” due to missing values

Overwrite samtools-flagstats default to present a table instead of a violin plot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/52)
<!-- Reviewable:end -->
