### PR TITLE
Add sex_check output to TSO500 MultiQC

### DIFF
--- a/TSO500/TSO500_multiqc_config_v2.3.0.yaml
+++ b/TSO500/TSO500_multiqc_config_v2.3.0.yaml
@@ -104,7 +104,7 @@ custom_data:
     plot_type: "table"
     pconfig:
       id: "tso500_metricsoutput_dna"
-      title: "TSO500 MetricsOutput RNA"
+      title: "TSO500 MetricsOutput DNA"
       scale: false
     headers:
       COMPLETED_ALL_STEPS:
@@ -155,35 +155,6 @@ custom_data:
         description: "Median Bin Count CNV Target"
         format: '{:,.1f}'
         placement: 1000
-  metricsoutput_rna:
-    file_format: "tsv"
-    section_name: "MetricsOutput RNA"
-    description: "This table comes from the MetricsOutput.tsv file of eggd_tso500"
-    plot_type: "table"
-    pconfig:
-      id: "tso500_metricsoutput_rna"
-      title: "TSO500 MetricsOutput RNA"
-      scale: false
-    headers:
-      COMPLETED_ALL_STEPS:
-        title: "Completed"
-        description: "Are all steps completed?"
-        placement: 100
-      MEDIAN_CV_GENE_500X:
-        title: "CV Gene 500x"
-        description: "Median CV Gene 500x"
-        format: '{:,.2f}'
-        placement: 200
-      TOTAL_ON_TARGET_READS:
-        title: "Target Reads"
-        description: "Total On Target Reads"
-        format: '{:,.0f}'
-        placement: 300
-      MEDIAN_INSERT_SIZE_RNA:
-        title: "Insert Size"
-        description: "Median Insert Size RNA"
-        format: '{:,.0f}'
-        placement: 400
 
 table_cond_formatting_colours:
     - blue: '#337ab7'
@@ -217,9 +188,6 @@ table_cond_formatting_rules:
   TOTAL_ON_TARGET_READS:
     fail:
       - lt: 9000000
-  MEDIAN_INSERT_SIZE_RNA:
-    fail:
-      - lt: 80
 
 # Overwrite module order (in report).
 # See multiqc/utils/config_defaults.yaml for the defaults.
@@ -251,8 +219,6 @@ sp:
     #     contents: 'in total (QC-passed reads + QC-failed reads)'
     metricsoutput_dna:
         fn: 'MetricsOutput_MultiQC_DNA.tsv'
-    metricsoutput_rna:
-        fn: 'MetricsOutput_MultiQC_RNA.tsv'
     picard/variant_calling_metrics:
         fn: '*variantcallingmetrics.variant_calling_detail_metrics'
         shared: true
@@ -275,8 +241,6 @@ dx_sp:
             - '*.stats-fastqc.txt'
         metricsoutput_dna:
             - 'MetricsOutput_MultiQC_DNA.tsv'
-        metricsoutput_rna:
-            - 'MetricsOutput_MultiQC_RNA.tsv'
         picard/QC:
             - '*variantcallingmetrics.variant_calling_detail_metrics'
         sex_check:

--- a/TSO500/TSO500_multiqc_config_v2.3.0.yaml
+++ b/TSO500/TSO500_multiqc_config_v2.3.0.yaml
@@ -185,6 +185,13 @@ custom_data:
         format: '{:,.0f}'
         placement: 400
 
+table_cond_formatting_colours:
+    - blue: '#337ab7'
+    - lbue: '#5bc0de'
+    - pass: '#5cb85c'
+    - warn: '#f0ad4e'
+    - fail: '#d9534f'
+
 table_cond_formatting_rules:
   MEDIAN_INSERT_SIZE:
     fail:

--- a/TSO500/TSO500_multiqc_config_v2.3.0.yaml
+++ b/TSO500/TSO500_multiqc_config_v2.3.0.yaml
@@ -272,3 +272,5 @@ dx_sp:
             - 'MetricsOutput_MultiQC_RNA.tsv'
         picard/QC:
             - '*variantcallingmetrics.variant_calling_detail_metrics'
+        sex_check:
+            - "*_mqc.json"


### PR DESCRIPTION
Changes:

- update filename
- remove MetricsOutput RNA references because TSO500 no longer handles RNA, PCAN does
- add `table_cond_formatting_colours` to allow correct highlighting of sex_check columns
- add output of eggd_sex_check to `dx_sp`

Brief testing for this config: https://platform.dnanexus.com/panx/projects/J6YJkv044YpzB3zp2xfP288Q/monitor/job/J6qzvX044YppfbqGk1P6J20k (note the sex check doesn't match what is on the ticket because different thresholds were used, which haven't been signed off)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/61)
<!-- Reviewable:end -->
