### PR TITLE
DI-3412 atlas v1.0.0 dev

### DIFF
--- a/CGP/CGP_multiqc_config_v1.0.0.yaml
+++ b/CGP/CGP_multiqc_config_v1.0.0.yaml
@@ -107,7 +107,6 @@ use_filename_as_sample_name:
     - picard/markdups
     - picard/gcbias
     - picard/pcr_metrics
-    - picard/insertsize
     - picard/quality_by_cycle
     - picard/quality_score_distribution
 
@@ -117,6 +116,7 @@ module_order:
     - verifybamid:
         extra: ""
     - picard
+    - sentieon_umi
     - samtools
     - fastqc
     - bcl2fastq
@@ -226,12 +226,6 @@ table_cond_formatting_rules:
         warn:
             - eq: 10
             - gt: 10
-    picard_insertsizemetrics-summed_median: # Picard Median Insert Size
-        pass:
-            - gt: 150
-        warn:
-            - eq: 150
-            - lt: 150
     hsmetrics-FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
         pass:
             - lt: 1.80
@@ -311,21 +305,16 @@ custom_data:
                 min: 0
 
 sp:
+    sentieon_umi/insertsize:
+        fn: '*.InsertSize_metrics.txt'
+        shared: true
     fastqc/data:
-        - fn: '*EGG2*.stats-fastqc.txt'
-        - fn: '*-8128-*.stats-fastqc.txt'
-        - fn: '*-8476-*.stats-fastqc.txt'
-        - fn: '*-5877-*.stats-fastqc.txt'
-        - fn: '*-2327-*.stats-fastqc.txt'
-        - fn: '*-10051-*.stats-fastqc.txt'
+        - fn: '*CGP*.stats-fastqc.txt'
     picard/alignment_metrics:
         fn: '*.alignment_summary_metrics'
         shared: true
     picard/markdups:
         fn: '*.dedup_metrics.txt'
-        shared: true
-    picard/insertsize:
-        fn: '*.InsertSize_metrics.txt'
         shared: true
     picard/hsmetrics:
         fn: '*.hsmetrics.tsv'
@@ -374,13 +363,14 @@ remove_sections:
 
 dx_sp:
     primary:
+        sentieon_umi:
+            - '*.InsertSize_metrics.txt'
         fastqc:
             - '*.stats-fastqc.txt'
         picard/QC:
             - '*.alignment_summary_metrics'
             - '*.hsmetrics.tsv'
             - '*.gc_bias.detail_metrics'
-            - '*.insert_size_metrics'
             - '*.pertarget_coverage.tsv'
             - '*.variantcallingmetrics.variant_calling_detail_metrics'
             - '*.dedup_metrics.txt'

--- a/CGP/CGP_multiqc_config_v1.0.0.yaml
+++ b/CGP/CGP_multiqc_config_v1.0.0.yaml
@@ -107,6 +107,7 @@ use_filename_as_sample_name:
     - picard/markdups
     - picard/gcbias
     - picard/pcr_metrics
+    - picard/insertsize
     - picard/quality_by_cycle
     - picard/quality_score_distribution
 
@@ -116,7 +117,6 @@ module_order:
     - verifybamid:
         extra: ""
     - picard
-    - sentieon_umi
     - samtools
     - fastqc
     - bcl2fastq
@@ -129,8 +129,6 @@ report_section_order:
         order: 9990
     sex_check:
         order: 9980
-    sentieon_umi:
-        order: 9970
     samplesheet_samplename_patterns:
         order: 10
 
@@ -162,6 +160,7 @@ table_columns_placement:
         250x: 950
         summed_median: 960
         PCT_AMPLIFIED_BASES: 970
+        Usable_unique_bases_on_target: 980
 
 picard_config:
     general_stats_target_coverage:
@@ -227,6 +226,12 @@ table_cond_formatting_rules:
         warn:
             - eq: 10
             - gt: 10
+    picard_insertsizemetrics-summed_median: # Picard Median Insert Size
+        pass:
+            - gt: 150
+        warn:
+            - eq: 150
+            - lt: 150
     hsmetrics-FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
         pass:
             - lt: 1.80
@@ -269,7 +274,12 @@ custom_data:
                 max: 100
                 min: 0
                 suffix: '%'
-            
+            - Usable unique bases on-target:
+                description: 'Percentage of unique bases on target'
+                title: '% Usable unique bases on-target'
+                max: 100
+                min: 0
+                suffix: '%'
     samplesheet_wells:
         file_format: 'tsv'
         plot_type: 'generalstats'
@@ -367,6 +377,7 @@ dx_sp:
             - '*.alignment_summary_metrics'
             - '*.hsmetrics.tsv'
             - '*.gc_bias.detail_metrics'
+            - '*.insert_size_metrics'
             - '*.pertarget_coverage.tsv'
             - '*.variantcallingmetrics.variant_calling_detail_metrics'
             - '*.dedup_metrics.txt'

--- a/CGP/CGP_multiqc_config_v1.0.0.yaml
+++ b/CGP/CGP_multiqc_config_v1.0.0.yaml
@@ -160,7 +160,6 @@ table_columns_placement:
         250x: 950
         summed_median: 960
         PCT_AMPLIFIED_BASES: 970
-        Usable_unique_bases_on_target: 980
 
 picard_config:
     general_stats_target_coverage:
@@ -271,12 +270,6 @@ custom_data:
             - 1000x:
                 description: 'Target bases coverage at custom depth'
                 title: '%coverage at 1000x'
-                max: 100
-                min: 0
-                suffix: '%'
-            - Usable unique bases on-target:
-                description: 'Percentage of unique bases on target'
-                title: '% Usable unique bases on-target'
                 max: 100
                 min: 0
                 suffix: '%'

--- a/CGP/CGP_multiqc_config_v1.0.0.yaml
+++ b/CGP/CGP_multiqc_config_v1.0.0.yaml
@@ -160,7 +160,6 @@ table_columns_placement:
         250x: 950
         summed_median: 960
         PCT_AMPLIFIED_BASES: 970
-        Usable_unique_bases_on_target: 980
 
 picard_config:
     general_stats_target_coverage:
@@ -268,12 +267,7 @@ custom_data:
                 max: 100
                 min: 0
                 suffix: '%'
-            - Usable unique bases on-target:
-                description: 'Percentage of unique bases on target'
-                title: '% Usable unique bases on-target'
-                max: 100
-                min: 0
-                suffix: '%'
+            
     samplesheet_wells:
         file_format: 'tsv'
         plot_type: 'generalstats'

--- a/CGP/CGP_multiqc_config_v1.0.0.yaml
+++ b/CGP/CGP_multiqc_config_v1.0.0.yaml
@@ -129,6 +129,8 @@ report_section_order:
         order: 9990
     sex_check:
         order: 9980
+    sentieon_umi:
+        order: 9970
     samplesheet_samplename_patterns:
         order: 10
 


### PR DESCRIPTION
- Fix for the picard insert size issue.
- Remove usable bases on target as that is for MYE 
- Use fastqc data which have CGP in it 

Example job: https://platform.dnanexus.com/panx/projects/J9V284Q42Q966GY6102F1xpV/monitor/job/J9zPbzQ42Q9348261q9X5vxx

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_MultiQC_configs/69)
<!-- Reviewable:end -->
